### PR TITLE
Fix EXC_BAD_ACCESS from KVO re-entrancy in HPScrollView.observeValue

### DIFF
--- a/HPParallaxHeader/Classes/HPScrollView.swift
+++ b/HPParallaxHeader/Classes/HPScrollView.swift
@@ -47,6 +47,14 @@ open class HPScrollView : UIScrollView {
     private var isObserving: Bool = true
     private var lock: Bool = false
     private var isScrollingToTop: Bool = false
+    // FIX: Guards against KVO re-entrancy in observeValue(...).
+    // observeValue calls scrollView(_:setContentOffset:), which assigns
+    // contentOffset and synchronously fires another contentOffset KVO,
+    // re-entering observeValue. During that re-entrant call the
+    // `change as? CGPoint` downcast can crash with EXC_BAD_ACCESS while the
+    // Swift runtime resolves metadata. KVO is delivered synchronously on the
+    // main thread, so a simple Bool is enough to detect the re-entry.
+    private var isHandlingObservation: Bool = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -160,7 +168,17 @@ extension HPScrollView {
         guard context == &HPScrollView.KVOContext && keyPath == #keyPath(UIScrollView.contentOffset) else {
             return super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }
-        
+
+        // FIX: KVO re-entrancy guard.
+        // The body below calls scrollView(_:setContentOffset:), which changes
+        // contentOffset and re-enters this method synchronously via KVO. During
+        // that re-entry the `change as? CGPoint` downcast can race with Swift
+        // metadata resolution and crash with EXC_BAD_ACCESS, so bail out as soon
+        // as a re-entry is detected.
+        if isHandlingObservation { return }
+        isHandlingObservation = true
+        defer { isHandlingObservation = false }
+
         guard let scrollView = object as? UIScrollView,
             let new = change?[.newKey] as? CGPoint,
             let old = change?[.oldKey] as? CGPoint else { return }
@@ -224,6 +242,32 @@ extension HPScrollView {
     }
 
     func scrollView(_ scrollView: UIScrollView, setContentOffset offset: CGPoint) {
+        // FIX(1): Skip the assignment when the target equals the current offset.
+        // Assigning contentOffset fires a KVO notification even when the value
+        // does not change, which can drive the re-entrant layout/allocation that
+        // crashes. Sub-pixel differences are treated as equal.
+        let current = scrollView.contentOffset
+        if abs(current.x - offset.x) < 0.5, abs(current.y - offset.y) < 0.5 {
+            return
+        }
+
+        // FIX(2): When called from inside observeValue (i.e. during a layout /
+        // KVO re-entrancy), assigning contentOffset synchronously fires
+        // _NSSetPointValueAndNotify in the middle of layoutBelowIfNeeded and can
+        // mutate the CA::Layer hierarchy, crashing with EXC_BAD_ACCESS. Defer the
+        // assignment to the next run loop so it runs after layout settles.
+        if isHandlingObservation {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                let now = scrollView.contentOffset
+                if abs(now.x - offset.x) < 0.5, abs(now.y - offset.y) < 0.5 { return }
+                self.isObserving = false
+                scrollView.contentOffset = offset
+                self.isObserving = true
+            }
+            return
+        }
+
         isObserving = false
         scrollView.contentOffset = offset
         isObserving = true


### PR DESCRIPTION
When `HPScrollView.observeValue(forKeyPath:of:change:context:)` reacts to a `contentOffset` change, it calls `scrollView(_:setContentOffset:)`, which assigns `contentOffset` and synchronously re-enters `observeValue` through KVO.

During that re-entrant call:
- the `change as? CGPoint` downcast can race with Swift metadata resolution, and
- the `contentOffset` assignment runs in the middle of `layoutBelowIfNeeded` and mutates the `CA::Layer` hierarchy,

both of which can crash with `EXC_BAD_ACCESS`. We saw this as the top crash in production (notably on iOS 26, where SwiftUI-hosting cells make the re-entrant layout path more likely).

## Changes
- Add a re-entrancy guard in `observeValue` (`isHandlingObservation`) so the re-entrant call bails out before the risky downcast.
- Skip the `setContentOffset` assignment when the target equals the current offset (sub-pixel), avoiding unnecessary KVO notifications.
- When `setContentOffset` is called re-entrantly (from inside `observeValue`), defer the assignment to the next run loop so it runs after layout settles instead of mutating layers mid-layout.

No public API changes. Normal scrolling behaviour is unchanged in our testing; the deferred assignment only triggers in the re-entrant path.
